### PR TITLE
Implement core extension modules

### DIFF
--- a/background.js
+++ b/background.js
@@ -1,0 +1,1 @@
+// Placeholder background script for future use

--- a/manifest.json
+++ b/manifest.json
@@ -1,0 +1,14 @@
+{
+  "manifest_version": 3,
+  "name": "GPT Hallucination Detector",
+  "description": "Detects potential hallucinations in ChatGPT responses",
+  "version": "0.1",
+  "permissions": ["activeTab", "storage"],
+  "content_scripts": [
+    {
+      "matches": ["https://chat.openai.com/*"],
+      "js": ["src/content/index.js"],
+      "css": ["src/assets/styles.css"]
+    }
+  ]
+}

--- a/src/assets/styles.css
+++ b/src/assets/styles.css
@@ -1,0 +1,10 @@
+.gpt-hallucination-flag {
+    background: yellow;
+    padding: 2px 4px;
+    border-radius: 3px;
+    font-size: 12px;
+    cursor: pointer;
+}
+.gpt-toggle-btn {
+    font-size: 12px;
+}

--- a/src/config/heuristics-config.js
+++ b/src/config/heuristics-config.js
@@ -1,0 +1,3 @@
+export default {
+    responseTimeThreshold: 5000 // ms
+};

--- a/src/content/gpt-extractor.js
+++ b/src/content/gpt-extractor.js
@@ -1,0 +1,23 @@
+import { logInfo } from '../utils/logging';
+
+/**
+ * Extracts the latest user prompt and GPT response from the DOM.
+ * Returns { promptText, responseText, responseNode }
+ */
+export function extractLatestExchange() {
+    const userMessages = document.querySelectorAll('.request-:text, .message.user');
+    const assistantMessages = document.querySelectorAll('.result-streaming, .message.assistant');
+
+    const latestUser = userMessages[userMessages.length - 1];
+    const latestAssistant = assistantMessages[assistantMessages.length - 1];
+
+    if (!latestUser || !latestAssistant) {
+        logInfo('Could not locate latest exchange');
+        return null;
+    }
+
+    const promptText = latestUser.innerText || '';
+    const responseText = latestAssistant.innerText || '';
+
+    return { promptText, responseText, responseNode: latestAssistant };
+}

--- a/src/content/heuristics-engine.js
+++ b/src/content/heuristics-engine.js
@@ -1,0 +1,74 @@
+import { logInfo } from '../utils/logging';
+import config from '../config/heuristics-config';
+
+function checkResponseTime(metadata) {
+    const duration = metadata.endTime - metadata.startTime;
+    if (duration > config.responseTimeThreshold) {
+        return {
+            flagType: 'response_time',
+            confidence: 'moderate',
+            tooltipText: `Long response time (${duration}ms)`,
+            source: 'heuristic_response_time'
+        };
+    }
+    return null;
+}
+
+function checkRoteLanguage(text) {
+    const rotePatterns = /(Certainly!|In conclusion|As an AI language model)/i;
+    if (rotePatterns.test(text)) {
+        return {
+            flagType: 'rote_format',
+            confidence: 'moderate',
+            tooltipText: 'Response uses templated phrasing',
+            source: 'heuristic_rote'
+        };
+    }
+    return null;
+}
+
+function checkBadCitation(text) {
+    const urlRegex = /(https?:\/\/[^\s]+)/g;
+    const urls = text.match(urlRegex) || [];
+    const badUrls = urls.filter(u => /example\.com/.test(u));
+    if (badUrls.length) {
+        return {
+            flagType: 'bad_citation',
+            confidence: 'high',
+            tooltipText: 'Unverified or malformed citation',
+            source: 'heuristic_citation'
+        };
+    }
+    return null;
+}
+
+function checkPromptAmbiguity(prompt) {
+    const ambiguous = /(it|this|that)/i.test(prompt) && /\b(first|then)\b/i.test(prompt);
+    if (ambiguous) {
+        return {
+            flagType: 'prompt_ambiguity',
+            confidence: 'moderate',
+            tooltipText: 'Prompt may be ambiguous',
+            source: 'heuristic_prompt'
+        };
+    }
+    return null;
+}
+
+export function runHeuristics({ promptText, responseText, metadata }) {
+    const flags = [];
+    const checkers = [
+        () => checkResponseTime(metadata),
+        () => checkRoteLanguage(responseText),
+        () => checkBadCitation(responseText),
+        () => checkPromptAmbiguity(promptText)
+    ];
+
+    checkers.forEach(check => {
+        const result = check();
+        if (result) flags.push(result);
+    });
+
+    logInfo('Heuristics executed', { flags });
+    return flags;
+}

--- a/src/content/index.js
+++ b/src/content/index.js
@@ -1,0 +1,27 @@
+import { initializeDomListener } from './dom-listener';
+import { extractLatestExchange } from './gpt-extractor';
+import { runHeuristics } from './heuristics-engine';
+import { displayFlags } from './overlay-ui';
+import { initToggle, extensionEnabled } from './toggles';
+import { sendTelemetry } from './telemetry';
+
+initToggle();
+
+initializeDomListener(metadata => {
+    if (!extensionEnabled()) return;
+
+    const exchange = extractLatestExchange();
+    if (!exchange) return;
+
+    const flags = runHeuristics({
+        promptText: exchange.promptText,
+        responseText: exchange.responseText,
+        metadata
+    });
+
+    displayFlags(exchange.responseNode, flags);
+
+    if (flags.length) {
+        sendTelemetry({ flags, prompt: exchange.promptText });
+    }
+});

--- a/src/content/overlay-ui.js
+++ b/src/content/overlay-ui.js
@@ -1,0 +1,26 @@
+import { createElement } from '../utils/dom-utils';
+import { logInfo } from '../utils/logging';
+
+const FLAG_CLASS = 'gpt-hallucination-flag';
+
+function buildFlagElement(flags) {
+    const tooltipText = flags.map(f => f.tooltipText).join('\n');
+    return createElement('div', {
+        class: FLAG_CLASS,
+        title: tooltipText
+    }, [document.createTextNode('⚠️')]);
+}
+
+export function displayFlags(responseNode, flags) {
+    if (!responseNode || !flags.length) return;
+    const existing = responseNode.querySelector(`.${FLAG_CLASS}`);
+    if (existing) existing.remove();
+
+    const flagEl = buildFlagElement(flags);
+    responseNode.style.position = 'relative';
+    flagEl.style.position = 'absolute';
+    flagEl.style.top = '0';
+    flagEl.style.right = '0';
+    responseNode.appendChild(flagEl);
+    logInfo('Flags displayed', { count: flags.length });
+}

--- a/src/content/telemetry.js
+++ b/src/content/telemetry.js
@@ -1,0 +1,16 @@
+import { logError, logInfo } from '../utils/logging';
+
+const ENDPOINT = 'https://example.com/telemetry';
+
+export async function sendTelemetry(data) {
+    try {
+        await fetch(ENDPOINT, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify(data)
+        });
+        logInfo('Telemetry sent');
+    } catch (err) {
+        logError('Telemetry failed', err);
+    }
+}

--- a/src/content/toggles.js
+++ b/src/content/toggles.js
@@ -1,0 +1,26 @@
+import { createElement } from '../utils/dom-utils';
+import { logInfo } from '../utils/logging';
+
+let enabled = true;
+let toggleBtn;
+
+export function initToggle() {
+    toggleBtn = createElement('button', { class: 'gpt-toggle-btn' }, [document.createTextNode('Hallucination Monitor')]);
+    toggleBtn.style.position = 'fixed';
+    toggleBtn.style.bottom = '10px';
+    toggleBtn.style.right = '10px';
+    toggleBtn.style.zIndex = '9999';
+    toggleBtn.style.padding = '6px';
+    toggleBtn.style.background = '#fff';
+    toggleBtn.style.border = '1px solid #ccc';
+    toggleBtn.addEventListener('click', () => {
+        enabled = !enabled;
+        toggleBtn.style.opacity = enabled ? '1' : '0.5';
+        logInfo(`Extension ${enabled ? 'enabled' : 'disabled'}`);
+    });
+    document.body.appendChild(toggleBtn);
+}
+
+export function extensionEnabled() {
+    return enabled;
+}

--- a/src/utils/dom-utils.js
+++ b/src/utils/dom-utils.js
@@ -1,0 +1,14 @@
+export function createElement(tag, attrs = {}, children = []) {
+    const el = document.createElement(tag);
+    Object.entries(attrs).forEach(([key, value]) => {
+        if (key === 'class') {
+            el.className = value;
+        } else if (key === 'style') {
+            Object.assign(el.style, value);
+        } else {
+            el.setAttribute(key, value);
+        }
+    });
+    children.forEach(child => el.appendChild(child));
+    return el;
+}

--- a/src/utils/logging.js
+++ b/src/utils/logging.js
@@ -1,0 +1,7 @@
+export function logInfo(message, data = {}) {
+    console.log(`[GPT-Extension] ${message}`, data);
+}
+
+export function logError(message, error) {
+    console.error(`[GPT-Extension] ${message}`, error);
+}

--- a/src/utils/timing-util.js
+++ b/src/utils/timing-util.js
@@ -1,0 +1,7 @@
+export function debounce(fn, delay) {
+    let timeoutId;
+    return function (...args) {
+        clearTimeout(timeoutId);
+        timeoutId = setTimeout(() => fn.apply(this, args), delay);
+    };
+}


### PR DESCRIPTION
## Summary
- add working Manifest V3 file
- add logging, timing, and DOM utility helpers
- implement GPT response extraction
- implement heuristics engine with four rules
- display flags in overlay and add toggle button
- send telemetry placeholder
- wire everything together in content script

## Testing
- `git status --short`
- `git log -1 --stat`


------
https://chatgpt.com/codex/tasks/task_e_684860f9cd2c8321b4bd315185f591ab