### PR TITLE
Update manifest and telemetry docs

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -4,6 +4,7 @@
   "description": "Detects potential hallucinations in ChatGPT responses",
   "version": "0.1",
   "permissions": ["activeTab", "storage"],
+  "host_permissions": ["https://example.com/*"],
   "content_scripts": [
     {
       "matches": ["https://chat.openai.com/*"],

--- a/modules/6-telemetry.md
+++ b/modules/6-telemetry.md
@@ -14,3 +14,7 @@ Collects anonymous heuristic results and user feedback for later review and impr
 ## Must Not
 - Send any PII
 - Delay UI or block frontend rendering
+
+## Configuration
+The telemetry endpoint domain can be customized. Update the `ENDPOINT` constant
+in `src/content/telemetry.js` to point at your own collection server.


### PR DESCRIPTION
## Summary
- allow access to https://example.com via host_permissions
- clarify telemetry endpoint configuration

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68487065a2a48321876f1e995e873f22