### PR TITLE
Fix prompt selector and return nodes

### DIFF
--- a/src/content/gpt-extractor.js
+++ b/src/content/gpt-extractor.js
@@ -2,11 +2,19 @@ import { logInfo } from '../utils/logging';
 
 /**
  * Extracts the latest user prompt and GPT response from the DOM.
- * Returns { promptText, responseText, responseNode }
+ * Returns { promptText, responseText, promptNode, responseNode }
  */
 export function extractLatestExchange() {
-    const userMessages = document.querySelectorAll('.request-:text, .message.user');
+    // ChatGPT renders user prompts within elements using the `request-text` class
+    // while assistant responses use `result-streaming`. Older layouts fall back
+    // to `.message.user` and `.message.assistant`.
+    const userMessages = document.querySelectorAll('.request-text, .message.user');
     const assistantMessages = document.querySelectorAll('.result-streaming, .message.assistant');
+
+    if (!userMessages.length || !assistantMessages.length) {
+        logInfo('Could not locate latest exchange');
+        return null;
+    }
 
     const latestUser = userMessages[userMessages.length - 1];
     const latestAssistant = assistantMessages[assistantMessages.length - 1];
@@ -18,6 +26,10 @@ export function extractLatestExchange() {
 
     const promptText = latestUser.innerText || '';
     const responseText = latestAssistant.innerText || '';
-
-    return { promptText, responseText, responseNode: latestAssistant };
+    return {
+        promptText,
+        responseText,
+        promptNode: latestUser,
+        responseNode: latestAssistant
+    };
 }


### PR DESCRIPTION
## Summary
- fix selector in GPT extractor
- return both prompt and response nodes

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_6848704bf3c4832198f53d00f49c21ec