### PR TITLE
Add testing banner and support chatgpt.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,26 @@
+# GPT Hallucination Detector
+
+This Chrome/Chromium extension flags potential hallucinations in ChatGPT responses using simple heuristics.
+
+## Loading the Extension
+
+1. Open Chromium-based browser (Chrome, Edge, etc.).
+2. Navigate to `chrome://extensions`.
+3. Enable **Developer mode** using the toggle in the top right.
+4. Click **Load unpacked** and select this repository's folder.
+
+The extension will run on both `https://chat.openai.com` and the redirected `https://chatgpt.com` domain once loaded.
+
+When the page loads, a brief "Hallucination Monitor loaded" banner appears near the toggle button so you can confirm the extension is active.
+
+## Observing Heuristic Flags
+
+When ChatGPT produces a response that matches one of the built-in heuristics (slow response, rote phrasing, suspicious citation, or ambiguous prompt), a small `⚠️` icon will appear in the top-right corner of the response box. Hover to see a tooltip describing the reason.
+
+## Disabling the Extension
+
+A floating "Hallucination Monitor" button appears in the bottom-right corner of the page. Click it to toggle the extension on or off. The button becomes semi-transparent when disabled.
+
+## Manual Testing
+
+This repository contains no automated tests. Evaluate behavior manually in the browser. Heuristic results are approximate and may produce false positives or miss some hallucinations. Use the toggle button to temporarily disable the extension if needed during manual experiments. You can also open the console and call `hallucinationMonitorTest()` to display a test banner confirming the script is active.

--- a/manifest.json
+++ b/manifest.json
@@ -6,7 +6,10 @@
   "permissions": ["activeTab", "storage"],
   "content_scripts": [
     {
-      "matches": ["https://chat.openai.com/*"],
+      "matches": [
+        "https://chat.openai.com/*",
+        "https://chatgpt.com/*"
+      ],
       "js": ["src/content/index.js"],
       "css": ["src/assets/styles.css"]
     }

--- a/src/assets/styles.css
+++ b/src/assets/styles.css
@@ -8,3 +8,7 @@
 .gpt-toggle-btn {
     font-size: 12px;
 }
+
+.gpt-status-banner {
+    border-radius: 3px;
+}

--- a/src/content/index.js
+++ b/src/content/index.js
@@ -2,10 +2,11 @@ import { initializeDomListener } from './dom-listener';
 import { extractLatestExchange } from './gpt-extractor';
 import { runHeuristics } from './heuristics-engine';
 import { displayFlags } from './overlay-ui';
-import { initToggle, extensionEnabled } from './toggles';
+import { initToggle, extensionEnabled, showStatusBanner } from './toggles';
 import { sendTelemetry } from './telemetry';
 
 initToggle();
+window.hallucinationMonitorTest = () => showStatusBanner('Extension test banner');
 
 initializeDomListener(metadata => {
     if (!extensionEnabled()) return;

--- a/src/content/toggles.js
+++ b/src/content/toggles.js
@@ -1,6 +1,20 @@
 import { createElement } from '../utils/dom-utils';
 import { logInfo } from '../utils/logging';
 
+export function showStatusBanner(text) {
+    const banner = createElement('div', { class: 'gpt-status-banner' }, [document.createTextNode(text)]);
+    banner.style.position = 'fixed';
+    banner.style.bottom = '50px';
+    banner.style.right = '10px';
+    banner.style.padding = '4px 6px';
+    banner.style.background = '#000';
+    banner.style.color = '#fff';
+    banner.style.fontSize = '12px';
+    banner.style.zIndex = '9999';
+    document.body.appendChild(banner);
+    setTimeout(() => banner.remove(), 3000);
+}
+
 let enabled = true;
 let toggleBtn;
 
@@ -19,6 +33,7 @@ export function initToggle() {
         logInfo(`Extension ${enabled ? 'enabled' : 'disabled'}`);
     });
     document.body.appendChild(toggleBtn);
+    showStatusBanner('Hallucination Monitor loaded');
 }
 
 export function extensionEnabled() {


### PR DESCRIPTION
## Summary
- support loading the extension on the newer `chatgpt.com` domain
- show a brief banner on page load so the extension is easy to verify
- expose `hallucinationMonitorTest()` for manual testing
- document the new domain and testing steps

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68487053199c8321b2a745c10f07cebc