### PR TITLE
Fix build instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,12 +9,11 @@ This Chrome/Chromium extension flags potential hallucinations in ChatGPT respons
 3. Enable **Developer mode** using the toggle in the top right.
 4. Click **Load unpacked** and select this repository's folder.
 
-Before loading the extension for the first time, install dependencies and build
-the bundled content script:
+Before loading the extension for the first time, install dependencies. The build
+step runs automatically:
 
 ```bash
 npm install
-npm run build
 ```
 
 The extension will run on both `https://chat.openai.com` and the redirected `https://chatgpt.com` domain once loaded.
@@ -24,14 +23,13 @@ When the page loads, a brief "Hallucination Monitor loaded" banner appears near 
 
 ## Build
 
-Install dependencies and bundle the extension before loading it:
+If you make changes to the source files, rebuild the bundled content script:
 
 ```bash
-npm install
 npm run build
 ```
 
-The bundled files appear in the `dist/` directory. Use **Load unpacked** on that folder instead of the repository root. Loading the source folder after building is a common pitfall that prevents the compiled scripts from running.
+The compiled file appears in the `dist/` directory next to the manifest. Load the repository root (not `dist/`) with **Load unpacked** so `manifest.json` can locate the bundled script.
 
 ## Observing Heuristic Flags
 

--- a/package.json
+++ b/package.json
@@ -1,19 +1,16 @@
 {
   "name": "gpt-hallucination-detector",
-  "version": "0.1.0",
-  "description": "Chrome extension to flag potential hallucinations in ChatGPT responses",
-  "scripts": {
-    "build": "rollup -c"
-  },
-  "devDependencies": {
-    "rollup": "^3.0.0",
-    "@rollup/plugin-node-resolve": "^15.0.0"
   "version": "1.0.0",
+  "description": "Chrome extension to flag potential hallucinations in ChatGPT responses",
   "type": "module",
   "scripts": {
+    "build": "rollup -c",
+    "postinstall": "npm run build",
     "test": "jest"
   },
   "devDependencies": {
+    "@rollup/plugin-node-resolve": "^15.0.0",
+    "rollup": "^3.0.0",
     "jest": "^29.6.1",
     "jest-environment-jsdom": "^30.0.0"
   },


### PR DESCRIPTION
## Summary
- make README consistent about loading the extension from the repository root
- fix `package.json` syntax and add a `postinstall` step so `npm install` builds automatically

## Testing
- `npm install`
- `npm test` *(fails: SyntaxError: Cannot use import statement outside a module)*

------
https://chatgpt.com/codex/tasks/task_e_68487a754f38832199b213ea2d325ebd